### PR TITLE
Change `.card img` max-height from 100px to 200px

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -186,7 +186,7 @@ h3 {
     display:block;
     margin: 0 auto;
     max-width: 200px;
-    max-height: 100px;
+    max-height: 200px;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
Proposing `.card img` to have a max-height of 200px instead of 100px. It will look more fab. Trust me.